### PR TITLE
Fix of the error when being 11th, 12th or 13th to successfully guess 

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -474,12 +474,16 @@
                 {:then rank}
                     <p class="mx-auto">
                         You are the {rank +
-                            (parseInt(rank) % 10 == 1
+                            /*This check will fail if that was the 11th, 111th, 211th, ... guess even if the number ends in 1.*/
+                            (parseInt(rank) % 10 == 1 && parseInt(rank) % 100 != 11 
                                 ? "st"
-                                : parseInt(rank) % 10 == 2
+                            /*This check will fail if that was the 12th, 112th, 212th, ... guess even if the number ends in 2.*/
+                                : parseInt(rank) % 10 == 2 && parseInt(rank) % 100 != 12
                                 ? "nd"
-                                : parseInt(rank) % 10 == 3
+                            /*This check will fail if that was the 13th, 113th, 213th, ... guess even if the number ends in 3.*/
+                                : parseInt(rank) % 10 == 3 && parseInt(rank) % 100 != 13
                                 ? "rd"
+                            /*Any number ending in 11, 12 or 13 will land here as appropriate in the English grammar the suffix of the ordinal is "th"*/
                                 : "th")} to guess today's weapon!
                     </p>
                 {/await}


### PR DESCRIPTION
Suggested fix for the error described in https://github.com/cxhuy/terradle-web/issues/4 :

Made that

- the check to put "st" fails if the number ends in 11 (11th, 111th, 211th, ...)
- the check to put "nd" fails if the number ends in 12 (12th, 112th, 212th, ...)
- the check to put "rd" fails if the number ends in 13 (13th, 113th, 213th, ...)

That way numbers ending in 11, 12 or 13 correctly land in the control flow branch to put "th" as suffix.